### PR TITLE
Add Skimp Maps demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Vibe-Coding-Project
+# Skimp Maps
+
+Skimp Maps is a simple web app to crowdsource reports of Chipotle restaurants that skimp on portions. The site consists of three pages:
+
+1. **Landing page** (`index.html`) – Explains what the project is and links to the map and submission form.
+2. **Map page** (`map.html`) – Displays a map with known Chipotle locations from `chipotle_locations.json`.
+3. **Add page** (`add.html`) – Lets users search for a Chipotle by ZIP code and submit their own report.
+
+To view the site locally just open `index.html` in a modern browser.
+
+## Deploying with GitHub Pages
+
+1. Commit the site files to a repository on GitHub.
+2. In the repository settings, enable GitHub Pages and choose the `main` branch as the source.
+3. After a few minutes your site will be available at `https://<username>.github.io/<repo>/`.
+

--- a/add.html
+++ b/add.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skimp Maps - Add Report</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 1rem; }
+    nav a { margin-right: 1rem; }
+    #results { margin-top: 1rem; }
+    .location { margin-bottom: 0.5rem; }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="map.html">View Map</a>
+  </nav>
+  <h1>Add a Chipotle</h1>
+  <p>Search by ZIP code to find Chipotle locations near you and add your report.</p>
+  <input type="text" id="zip" placeholder="ZIP code">
+  <button onclick="search()">Search</button>
+
+  <div id="results"></div>
+
+  <script>
+    let locations = [];
+    async function loadData() {
+      const response = await fetch('chipotle_locations.json');
+      locations = await response.json();
+    }
+    loadData();
+
+    function search() {
+      const zip = document.getElementById('zip').value.trim();
+      const container = document.getElementById('results');
+      container.innerHTML = '';
+      const matches = locations.filter(l => l.zip === zip);
+      if (matches.length === 0) {
+        container.textContent = 'No Chipotle locations found for that ZIP code.';
+        return;
+      }
+      matches.forEach(loc => {
+        const div = document.createElement('div');
+        div.className = 'location';
+        div.textContent = loc.address + ' (ZIP ' + loc.zip + ')';
+        const btn = document.createElement('button');
+        btn.textContent = 'Report Skimp';
+        btn.onclick = () => saveReport(loc);
+        div.appendChild(btn);
+        container.appendChild(div);
+      });
+    }
+
+    function saveReport(loc) {
+      const reports = JSON.parse(localStorage.getItem('reports') || '[]');
+      reports.push({ name: loc.name, address: loc.address, zip: loc.zip });
+      localStorage.setItem('reports', JSON.stringify(reports));
+      alert('Thank you! Your report was saved locally.');
+    }
+  </script>
+</body>
+</html>

--- a/chipotle_locations.json
+++ b/chipotle_locations.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "Chipotle Mexican Grill",
+    "address": "301 Massachusetts Ave, Boston, MA",
+    "zip": "02115",
+    "lat": 42.341,
+    "lng": -71.086
+  },
+  {
+    "name": "Chipotle Mexican Grill",
+    "address": "125 Summer St, Boston, MA",
+    "zip": "02110",
+    "lat": 42.353,
+    "lng": -71.057
+  },
+  {
+    "name": "Chipotle Mexican Grill",
+    "address": "1841 S Federal Hwy, Delray Beach, FL",
+    "zip": "33483",
+    "lat": 26.451,
+    "lng": -80.070
+  },
+  {
+    "name": "Chipotle Mexican Grill",
+    "address": "17 E 14th St, New York, NY",
+    "zip": "10003",
+    "lat": 40.735,
+    "lng": -73.993
+  },
+  {
+    "name": "Chipotle Mexican Grill",
+    "address": "5250 N Clark St, Chicago, IL",
+    "zip": "60640",
+    "lat": 41.977,
+    "lng": -87.668
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skimp Maps</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; }
+    header { text-align: center; }
+    nav a { margin: 0 1rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Skimp Maps</h1>
+    <p>Crowdsource reports of Chipotle locations that skimp on portions.</p>
+    <nav>
+      <a href="map.html">View Map</a>
+      <a href="add.html">Add a Report</a>
+    </nav>
+  </header>
+  <section>
+    <h2>What is Skimp Maps?</h2>
+    <p>Skimp Maps is a community-driven project. If a Chipotle restaurant appears on our map it means someone felt the portions were lacking. You can view locations and add your own report to help others avoid skimped meals.</p>
+  </section>
+</body>
+</html>

--- a/map.html
+++ b/map.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skimp Maps - Map</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <style>
+    body { margin: 0; font-family: Arial, sans-serif; }
+    #map { height: 90vh; }
+    nav { padding: 1rem; }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="add.html">Add a Report</a>
+  </nav>
+  <div id="map"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script>
+    async function init() {
+      const map = L.map('map').setView([39.5, -98.35], 4);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '© OpenStreetMap'
+      }).addTo(map);
+
+      const response = await fetch('chipotle_locations.json');
+      const locations = await response.json();
+      locations.forEach(loc => {
+        const marker = L.marker([loc.lat, loc.lng]).addTo(map);
+        marker.bindPopup(`<b>${loc.name}</b><br>${loc.address}<br>ZIP: ${loc.zip}`);
+      });
+    }
+    init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add landing page with links
- add map page powered by Leaflet
- add page for searching by ZIP and saving reports locally
- provide small sample dataset
- document how to deploy with GitHub pages

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684098f624508332972511567d341e63