### PR TITLE
Add radius-based search to Add page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Skimp Maps is a simple web app to crowdsource reports of Chipotle restaurants th
 1. **Landing page** (`index.html`) – Explains what the project is and links to the map and submission form.
 2. **Map page** (`map.html`) – Displays a map with known Chipotle locations from `chipotle_locations.json`.
 3. **Add page** (`add.html`) – Lets users search for a Chipotle by ZIP code and submit their own report.
+   The search tries to fetch live store data from the OpenStreetMap Overpass API
+   and falls back to the bundled `chipotle_locations.json` if that request
+   fails.
 
 To view the site locally just open `index.html` in a modern browser.
 

--- a/add.html
+++ b/add.html
@@ -19,6 +19,14 @@
   <h1>Add a Chipotle</h1>
   <p>Search by ZIP code to find Chipotle locations near you and add your report.</p>
   <input type="text" id="zip" placeholder="ZIP code">
+  <label for="radius">Radius:</label>
+  <select id="radius" onchange="toggleCustom()">
+    <option value="5">5 miles</option>
+    <option value="10">10 miles</option>
+    <option value="15">15 miles</option>
+    <option value="custom">Custom</option>
+  </select>
+  <input type="number" id="customRadius" placeholder="Miles" style="display:none; width:6em;">
   <button onclick="search()">Search</button>
 
   <div id="results"></div>
@@ -31,25 +39,99 @@
     }
     loadData();
 
-    function search() {
+    function toggleCustom() {
+      const select = document.getElementById('radius');
+      const custom = document.getElementById('customRadius');
+      custom.style.display = select.value === 'custom' ? 'inline' : 'none';
+    }
+
+    function getRadius() {
+      const select = document.getElementById('radius');
+      if (select.value === 'custom') {
+        const val = parseFloat(document.getElementById('customRadius').value);
+        return isNaN(val) || val <= 0 ? 5 : val;
+      }
+      return parseFloat(select.value);
+    }
+
+    async function fetchLiveChipotles(lat, lng, radiusMiles) {
+      const km = radiusMiles * 1.60934;
+      const query = `[out:json];node["name"~"Chipotle"](around:${Math.round(km * 1000)},${lat},${lng});out;`;
+      const url = 'https://overpass-api.de/api/interpreter?data=' + encodeURIComponent(query);
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error('Overpass error');
+      const data = await resp.json();
+      return data.elements.map(el => ({
+        name: el.tags.name || 'Chipotle Mexican Grill',
+        address: [el.tags['addr:housenumber'], el.tags['addr:street'], el.tags['addr:city'], el.tags['addr:state']].filter(Boolean).join(' '),
+        lat: el.lat,
+        lng: el.lon
+      }));
+    }
+
+    async function search() {
       const zip = document.getElementById('zip').value.trim();
       const container = document.getElementById('results');
       container.innerHTML = '';
-      const matches = locations.filter(l => l.zip === zip);
-      if (matches.length === 0) {
-        container.textContent = 'No Chipotle locations found for that ZIP code.';
+
+      if (!zip) {
+        container.textContent = 'Please enter a ZIP code.';
         return;
       }
-      matches.forEach(loc => {
+
+      let center;
+      try {
+        const resp = await fetch(`https://api.zippopotam.us/us/${zip}`);
+        if (!resp.ok) throw new Error('bad response');
+        const data = await resp.json();
+        const place = data.places[0];
+        center = { lat: parseFloat(place.latitude), lng: parseFloat(place.longitude) };
+      } catch (e) {
+        container.textContent = 'Could not locate that ZIP code.';
+        return;
+      }
+
+      const radius = getRadius();
+      let results = [];
+      try {
+        results = await fetchLiveChipotles(center.lat, center.lng, radius);
+      } catch (e) {
+        // fall back to bundled data
+        results = locations.filter(l => {
+          const d = distance(center.lat, center.lng, l.lat, l.lng);
+          return d <= radius;
+        });
+      }
+
+      if (results.length === 0) {
+        container.textContent = 'No Chipotle locations found within ' + radius + ' miles.';
+        return;
+      }
+
+      results.forEach(loc => {
         const div = document.createElement('div');
         div.className = 'location';
-        div.textContent = loc.address + ' (ZIP ' + loc.zip + ')';
+        let label = loc.address ? `${loc.name} - ${loc.address}` : loc.name;
+        if (loc.zip) label += ' (ZIP ' + loc.zip + ')';
+        div.textContent = label;
         const btn = document.createElement('button');
         btn.textContent = 'Report Skimp';
         btn.onclick = () => saveReport(loc);
         div.appendChild(btn);
         container.appendChild(div);
       });
+    }
+
+    function distance(lat1, lon1, lat2, lon2) {
+      const toRad = deg => deg * Math.PI / 180;
+      const R = 3958.8; // Earth radius in miles
+      const dLat = toRad(lat2 - lat1);
+      const dLon = toRad(lon2 - lon1);
+      const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
+                Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+                Math.sin(dLon/2) * Math.sin(dLon/2);
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+      return R * c;
     }
 
     function saveReport(loc) {


### PR DESCRIPTION
## Summary
- add radius dropdown and optional custom field
- use zippopotam.us API to look up coordinates for a ZIP code
- filter Chipotle locations within the chosen radius
- include Haversine distance function
- fetch live Chipotle locations from Overpass API with local fallback

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68409ce9b228833297d99fd3420fc11a